### PR TITLE
Rough in "charter" content in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in
 
 ## Deliverable
 
-* A ZARR Convention according to the draft described in [Zarr Enhancement Proposal 0004](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca) to be formatted as an OGC standard.
-* An OGC standard that describes the GeoZarr-spec convention as a full OGC standard. ([See two track standards process here for requirements of a full standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#the-two-track-standards-process-characteristics))
-* Contribution of any extension that is best housed in the CF-Convention.* 
+The geozarr-spec is a community effort to establish conventions for geospatial use cases in the cloud-native ZARR binary carrier. It is built from the existing conventions and implementation patterns. 
 
-> `* Likely to Appendix I, CF Data Model rather than the NetCDF-CF convention which is focused on the NetCDF data model specifically.`
+* A ZARR Convention according to the draft described in [Zarr Enhancement Proposal 0004](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca). 
+* An OGC standard that describes the GeoZarr-spec convention. ([See two track standards process here for requirements of a full vs community standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#the-two-track-standards-process-characteristics))
+* Contribution of any extension that is best housed in the CF-Convention.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in
 * Supporting advanced geospatial features for more accurate data representation and analysis.
 * Allowing scientists and researchers to work with diverse data types and projections in their preferred software and programming languages.
 
+## Deliverable
+
+* A ZARR Convention according to the draft described in [Zarr Enhancement Proposal 0004](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca)
+* An [OGC Community Standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#specific-process-requirements-for-the-submission-of-a-community-standard-cs) recognizing the GeoZarr-spec convention as an OGC.
+* Contribution of any extension that is best housed in the CF-Convention.* 
+
+> `* Likely to Appendix I, CF Data Model rather than the NetCDF-CF convention which is focused on the NetCDF data model specifically.`
+
 ## Status
 
 This specification early drafts (<=v0.4) were created initially by [Spacebel](https://www.spacebel.com/) for the [European Space Agency](https://esa.int) under the [General Support Technology Programme](http://www.esa.int/Enabling_Support/Space_Engineering_Technology/Shaping_the_Future/About_the_General_Support_Technology_Programme_GSTP).

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in
 
 ## Deliverable
 
-* A ZARR Convention according to the draft described in [Zarr Enhancement Proposal 0004](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca)
-* An [OGC Community Standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#specific-process-requirements-for-the-submission-of-a-community-standard-cs) recognizing the GeoZarr-spec convention as an OGC specification.
+* A ZARR Convention according to the draft described in [Zarr Enhancement Proposal 0004](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca) to be formatted as an OGC standard.
+* An OGC standard that describes the GeoZarr-spec convention as a full OGC standard. ([See two track standards process here for requirements of a full standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#the-two-track-standards-process-characteristics))
 * Contribution of any extension that is best housed in the CF-Convention.* 
 
 > `* Likely to Appendix I, CF Data Model rather than the NetCDF-CF convention which is focused on the NetCDF data model specifically.`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in the form of a _zarr convention_. Zarr specifies a protocol and format used for storing Zarr arrays, while GeoZarr defines **conventions** and recommendations for storing **multidimensional georeferenced grid** of geospatial observations (including rasters). See this draft [Zarr Enhanvement Proposal](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca) for further detail of the Zarr Convention process.
 
+## Scope
+
+* Easy compatibility with popular mapping and data analysis tools like GDAL, Xarray, ArcGIS, and QGIS.
+* Combining different types of geospatial data, like satellite images, elevation maps, and weather models.
+* Creating and displaying geospatial data in web browsers without complex workarounds
+* Helping users discover, access, and retrieve the data they need, including subsets or different arrangements of the data
+* Supporting advanced geospatial features for more accurate data representation and analysis.
+* Allowing scientists and researchers to work with diverse data types and projections in their preferred software and programming languages.
+
 ## Status
 
 This specification early drafts (<=v0.4) were created initially by [Spacebel](https://www.spacebel.com/) for the [European Space Agency](https://esa.int) under the [General Support Technology Programme](http://www.esa.int/Enabling_Support/Space_Engineering_Technology/Shaping_the_Future/About_the_General_Support_Technology_Programme_GSTP).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoZarr-Spec
 
-GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in the form of a _zarr convention_. Zarr specifies a protocol and format used for storing Zarr arrays, while GeoZarr defines **conventions** and recommendations for storing **multidimensional georeferenced grid** of geospatial observations (including rasters). See this draft [Zarr Enhanvement Proposal](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca) for further detail of the Zarr Convention process.
+GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in the form of a _zarr convention_. Zarr specifies a protocol and format used for storing Zarr arrays, while GeoZarr defines **conventions** and recommendations for storing **multidimensional georeferenced grid** of geospatial observations (including rasters). See this draft [Zarr Enhancement Proposal](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca) for further detail of the Zarr Convention process.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoZarr-Spec
 
-GeoZarr Spec aims to provide a geospatial extension to the Zarr specification. Zarr specifies a protocol and format used for storing Zarr arrays, while the present extension defines **conventions** and recommendations for storing **multidimensional georeferenced grid** of geospatial observations (including rasters). 
+GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in the form of a _zarr convention_. Zarr specifies a protocol and format used for storing Zarr arrays, while GeoZarr defines **conventions** and recommendations for storing **multidimensional georeferenced grid** of geospatial observations (including rasters). See this draft [Zarr Enhanvement Proposal](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca) for further detail of the Zarr Convention process.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in
 * Helping users discover, access, and retrieve the data they need, including subsets or different arrangements of the data
 * Supporting advanced geospatial features for more accurate data representation and analysis.
 * Allowing scientists and researchers to work with diverse data types and projections in their preferred software and programming languages.
-
+* Supporting serverless, cloud-native data analytics patterns on geospatial datacubes, including timeseries analysis.
 ## Deliverable
 
 The geozarr-spec is a community effort to establish conventions for geospatial use cases in the cloud-native ZARR binary carrier. It is built from existing data standards, conventions, and implementation patterns. The outcome of this work will be an implementable set of conventions. Next steps for formalization of a normative version of the conventions will be refined as the work progresses. Some key considerations follow.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in
 ## Deliverable
 
 * A ZARR Convention according to the draft described in [Zarr Enhancement Proposal 0004](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca)
-* An [OGC Community Standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#specific-process-requirements-for-the-submission-of-a-community-standard-cs) recognizing the GeoZarr-spec convention as an OGC.
+* An [OGC Community Standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#specific-process-requirements-for-the-submission-of-a-community-standard-cs) recognizing the GeoZarr-spec convention as an OGC specification.
 * Contribution of any extension that is best housed in the CF-Convention.* 
 
 > `* Likely to Appendix I, CF Data Model rather than the NetCDF-CF convention which is focused on the NetCDF data model specifically.`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GeoZarr Spec aims to provide a geospatial extension to the Zarr specification in
 
 ## Deliverable
 
-The geozarr-spec is a community effort to establish conventions for geospatial use cases in the cloud-native ZARR binary carrier. It is built from the existing conventions and implementation patterns. 
+The geozarr-spec is a community effort to establish conventions for geospatial use cases in the cloud-native ZARR binary carrier. It is built from existing data standards, conventions, and implementation patterns. The outcome of this work will be an implementable set of conventions. Next steps for formalization of a normative version of the conventions will be refined as the work progresses. Some key considerations follow.
 
 * A ZARR Convention according to the draft described in [Zarr Enhancement Proposal 0004](https://github.com/zarr-developers/zeps/pull/28/files?short_path=53e442a#diff-53e442aa938ca18ba1a94f845f264c5df0e4650f8f6abda856c3cd819f70abca). 
 * An OGC standard that describes the GeoZarr-spec convention. ([See two track standards process here for requirements of a full vs community standard](https://docs.opengeospatial.org/pol/05-020r27/05-020r27.html#the-two-track-standards-process-characteristics))


### PR DESCRIPTION
Per the discussion in #11 -- I think this is where we've landed for how we are going to jump into this.

In discussion with Jonathan Gregory, I've been advised that our goals around origin/offset style coordinates are not actually out of line with the CF data model documented in Appendix I and that we should probably just go ahead using that CF data model and implementing the compact origin/offset style coordinate variables needed for direct geotiff compatibility as an implementation of the CF data model seperate from the NetCDF-CF convention. I've noted that in deliverables. 

I'm not attached to any of this but wanted to move us along since it seems we are in agreement.
