### PR TITLE
make dimension binding for data variables match coordinate variables for zarr v3

### DIFF
--- a/standard/template/sections/clause_9_zarr_encoding_core.adoc
+++ b/standard/template/sections/clause_9_zarr_encoding_core.adoc
@@ -96,7 +96,7 @@ Data variables represent measured or derived quantities. They are stored as mult
 
 |Storage | Multidimensional array with `.zarray` and `.zattrs` | Same structure; v3 supports additional chunk storage formats
 
-|Dimension Association | `_ARRAY_DIMENSIONS` attribute | Same as v2
+|Dimension Binding | `_ARRAY_DIMENSIONS` in `.zattrs` | `dimension_names` in `zarr.json`
 
 |CF Metadata | `standard_name`, `units`, `long_name`, `_FillValue`, etc. | Same as v2; v3 may support typed attributes
 |===


### PR DESCRIPTION
this change makes the dimension binding for data variables match exactly the dimension binding for coordinate variables. for zarr v2, dimensions are declared in `_ARRAY_DIMENSIONS`'; for zarr v3, dimensions are declared in the `dimension_names` attribute of the array.

closes #80