### PR TITLE
Define versioning expectations for pilot conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,30 @@ Qualifying implementations are tracked in the [implementation matrix](https://ge
 
 ## 7. Versioning and releases
 
-The group follows semantic versioning for official releases. Minor editorial or encoding improvements may occur between major releases when consensus allows.
+### Constituent conventions
+
+Each constituent convention (geo-proj, spatial, multiscales, and any future GeoZarr conventions) is versioned in its own repository, tied to its maturity level in the [Zarr Conventions Framework](https://github.com/zarr-conventions/.github/blob/main/profile/README.md):
+
+- A convention SHOULD tag a pre-stable release (e.g. `v0.x`) once it reaches **Pilot** maturity (examples, a JSON Schema, and at least one implementation).
+- A convention SHOULD release an initial stable version once it reaches **Candidate** maturity, as defined by the implementation criteria in [§6](#6-implementation-criteria-for-candidate-maturity).
+
+The version-numbering scheme — for example, integer versions (`v1`) versus `major.minor`, and the relationship to Semantic Versioning — is under discussion in [#102](https://github.com/zarr-developers/geozarr-spec/issues/102) and [zarr-conventions-spec#29](https://github.com/zarr-conventions/zarr-conventions-spec/issues/29). A convention's UUID is permanent and MUST NOT change across versions.
+
+### The GeoZarr specification
+
+The GeoZarr specification is a document that **references** a set of conventions at pinned versions. It is versioned independently of those conventions, on its own editorial cadence: a new GeoZarr release may update prose or re-point a reference without any convention changing, and a convention may release a new version without forcing an immediate GeoZarr release.
+
+Each GeoZarr release records the exact convention versions it references (in the release notes and the specification's normative references), so that a given GeoZarr version resolves to a specific, reproducible set of conventions.
+
+**Release gate.** GeoZarr SHALL NOT release an initial stable version until every convention in the v1 suite — spatial, geo-proj, and multiscales — has reached **Candidate** maturity (per [§6](#6-implementation-criteria-for-candidate-maturity)). This makes a stable GeoZarr release a guarantee that its referenced conventions are individually mature, rather than an independent assertion.
+
+**OGC lifecycle precedence.** If GeoZarr enters the OGC Full Standards track before the release gate is met, OGC lifecycle rules govern the document's version number — under which a Standards document "shall start at 1.0" ([OGC TC Policies and Procedures §7.2](https://docs.ogc.org/pol/05-020r29/05-020r29.html#standards)) — and take precedence over the gate above.
+
+### Out of scope (tracked in [#102](https://github.com/zarr-developers/geozarr-spec/issues/102))
+
+- The version-numbering scheme for conventions and for GeoZarr (integer vs. `major.minor` vs. Semantic Versioning).
+- How GeoZarr versions after its initial stable release (e.g. when a referenced convention later issues a breaking change).
+- Whether conventions added after the v1 suite (e.g. CF, DGGS, TileMatrixSet) participate in the release gate.
 
 ## 8. Roadmap
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The [Zarr Conventions Framework](https://github.com/zarr-conventions/.github/blo
 
 ### Definitions
 
-An **implementation** is a software library, tool, or application that reads or writes Zarr data conforming to one or more GeoZarr conventions (geo-proj, spatial, multiscales).
+An **implementation** is a software library, tool, or application that reads or writes Zarr data conforming to one or more GeoZarr conventions (proj, spatial, multiscales).
 
 A **qualifying implementation** is one that meets all of the criteria below.
 
@@ -74,7 +74,7 @@ Independence ensures that conventions are interpretable from the specification a
 
 ### Convention coverage
 
-Each qualifying implementation MUST support at least one complete GeoZarr convention (geo-proj, spatial, or multiscales), including all required fields defined by the convention's JSON Schema.
+Each qualifying implementation MUST support at least one complete GeoZarr convention (proj, spatial, or multiscales), including all required fields defined by the convention's JSON Schema.
 
 Partial support does not count toward the 3-implementation threshold for that convention.
 
@@ -118,30 +118,87 @@ Qualifying implementations are tracked in the [implementation matrix](https://ge
 
 ## 7. Versioning and releases
 
-### Constituent conventions
+## 7. Versioning and releases
 
-Each constituent convention (geo-proj, spatial, multiscales, and any future GeoZarr conventions) is versioned in its own repository, tied to its maturity level in the [Zarr Conventions Framework](https://github.com/zarr-conventions/.github/blob/main/profile/README.md):
+### 7.1 How conventions are versioned
 
-- A convention SHOULD tag a pre-stable release (e.g. `v0.x`) once it reaches **Pilot** maturity (examples, a JSON Schema, and at least one implementation).
-- A convention SHOULD release an initial stable version once it reaches **Candidate** maturity, as defined by the implementation criteria in [§6](#6-implementation-criteria-for-candidate-maturity).
+Each constituent convention (proj, spatial, multiscales, and any future GeoZarr
+conventions) is versioned in its own repository and released via git tags, tied
+to its maturity level in the [Zarr Conventions
+Framework](https://github.com/zarr-conventions/.github/blob/main/profile/README.md).
+Every release publishes an **immutable, versioned artifact**: the specification
+text and JSON Schema for version `X.Y` are addressable at a URL that embeds the
+version and whose content never changes after release. Normative references
+MUST point at a versioned artifact, never at `main`, `latest`, or another
+mutable target. This applies to references in data, in tooling, and in the
+GeoZarr specification.
 
-The version-numbering scheme — for example, integer versions (`v1`) versus `major.minor`, and the relationship to Semantic Versioning — is under discussion in [#102](https://github.com/zarr-developers/geozarr-spec/issues/102) and [zarr-conventions-spec#29](https://github.com/zarr-conventions/zarr-conventions-spec/issues/29). A convention's UUID is permanent and MUST NOT change across versions.
+A convention's identity and its version are separate axes:
 
-### The GeoZarr specification
+- The **UUID** identifies the convention itself. It is permanent and MUST NOT
+  change across versions. If all URLs were lost, the UUID plus the conventions
+  registry would still resolve data to the correct specification.
+- The **version** identifies a specific released contract of that convention.
 
-The GeoZarr specification is a document that **references** a set of conventions at pinned versions. It is versioned independently of those conventions, on its own editorial cadence: a new GeoZarr release may update prose or re-point a reference without any convention changing, and a convention may release a new version without forcing an immediate GeoZarr release.
+The semantics of the `zarr_conventions` attribute are framework-level policy:
+how versions are carried in Zarr metadata, the rule that each declaration is
+self-contained (one convention at one version, via the versioned spec/schema
+URL alongside the UUID), and how declarations compose and resolve across a
+hierarchy. These semantics are defined in the [Zarr Conventions
+Framework
+specification](https://github.com/zarr-conventions/zarr-conventions-spec), not
+in this document, so that it applies uniformly to all conventions, geospatial
+or not. The operative consequences for GeoZarr: there is no store-wide or
+hierarchy-wide convention version attribute, and each declaration resolves
+independently at the node where it applies, so different nodes may reference
+different conventions without conflict.
 
-Each GeoZarr release records the exact convention versions it references (in the release notes and the specification's normative references), so that a given GeoZarr version resolves to a specific, reproducible set of conventions.
+### 7.2 Release expectations by maturity
 
-**Release gate.** GeoZarr SHALL NOT release an initial stable version until every convention in the v1 suite — spatial, geo-proj, and multiscales — has reached **Candidate** maturity (per [§6](#6-implementation-criteria-for-candidate-maturity)). This makes a stable GeoZarr release a guarantee that its referenced conventions are individually mature, rather than an independent assertion.
+- A convention SHOULD tag a pre-stable release (e.g. `v0.x`) once it reaches
+  **Pilot** maturity (examples, a JSON Schema, and at least one
+  implementation).
+- A convention SHOULD release an initial stable version once it reaches
+  **Candidate** maturity, as defined by the implementation criteria in
+  [§6](#6-implementation-criteria-for-candidate-maturity).
 
-**OGC lifecycle precedence.** If GeoZarr enters the OGC Full Standards track before the release gate is met, OGC lifecycle rules govern the document's version number — under which a Standards document "shall start at 1.0" ([OGC TC Policies and Procedures §7.2](https://docs.ogc.org/pol/05-020r29/05-020r29.html#standards)) — and take precedence over the gate above.
+### 7.3 Permanence of released versions
 
-### Out of scope (tracked in [#102](https://github.com/zarr-developers/geozarr-spec/issues/102))
+Once released, a convention version is **permanently published**:
 
-- The version-numbering scheme for conventions and for GeoZarr (integer vs. `major.minor` vs. Semantic Versioning).
-- How GeoZarr versions after its initial stable release (e.g. when a referenced convention later issues a breaking change).
-- Whether conventions added after the v1 suite (e.g. CF, DGGS, TileMatrixSet) participate in the release gate.
+- Every released version remains resolvable at its versioned URL indefinitely,
+  regardless of the convention's current maturity, the existence of newer
+  versions, or whether the GeoZarr specification still recommends it.
+- **Deprecation is a status, never a removal.** A deprecated or superseded
+  version is marked as such, with a pointer to its successor, but its text and
+  schema remain available so that data written against it decades ago remains
+  interpretable.
+- A later change in what the GeoZarr specification recommends affects only what
+  **newly written** data should do. It has no effect on the validity or
+  interpretability of existing data, which remains valid against the convention
+  version it declares, permanently.
+
+To make this durable beyond any single hosting platform, each stable release
+SHOULD additionally be archived in a platform-independent location (for
+example, a snapshot on a project-controlled domain, a Zenodo DOI, or Software
+Heritage), and the conventions registry maintains the permanent UUID → versions
+mapping as the layer of last resort.
+
+### 7.4 Out of scope (tracked in [#102](https://github.com/zarr-developers/geozarr-spec/issues/102))
+
+- The version-numbering scheme for conventions and for GeoZarr (integer vs.
+  `major.minor` vs. Semantic Versioning), including reader/writer compatibility
+  rules such as tolerance of unrecognized members. This is framework-level
+  policy and should be defined once in
+  [zarr-conventions-spec](https://github.com/zarr-conventions/zarr-conventions-spec)
+  (see
+  [zarr-conventions-spec#29](https://github.com/zarr-conventions/zarr-conventions-spec/issues/29))
+  so that validators and tooling resolve versions uniformly across all
+  conventions, rather than per convention or in this document.
+- How the GeoZarr specification references and versions against its constituent
+  conventions (follow-up PR).
+- The release gate for a stable GeoZarr release and its sequencing with the OGC
+  process (follow-up PR).
 
 ## 8. Roadmap
 


### PR DESCRIPTION
This PR documents the consensus on an initial convention version from https://github.com/zarr-conventions/proj/pull/20, https://github.com/zarr-conventions/zarr-conventions-spec/issues/29, https://github.com/zarr-conventions/zarr-conventions-spec/issues/7, and https://github.com/zarr-developers/geozarr-spec/issues/102. This consensus unlocks solving https://github.com/zarr-conventions/proj/issues/19 via a v0.1 release.

cc participants in those discussions @emmanuelmathot @d-v-b @kylebarron @pvanlaake

This PR also intentionally defers items where a clear consensus has not been reached, so that solving https://github.com/zarr-conventions/proj/issues/19 is not blocked by those discussions.