### PR TITLE
docs: fix name of proj convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ The conventions themselves are developed in their own repositories:
 
 | Convention | Repo |
 |------------|------|
-| **geo-proj** (`proj:`) | [zarr-conventions/geo-proj](https://github.com/zarr-conventions/geo-proj) |
-| **spatial** (`spatial:`) | [zarr-conventions/spatial](https://github.com/zarr-conventions/spatial) |
+| **proj** | [zarr-conventions/proj](https://github.com/zarr-conventions/proj) |
+| **spatial** | [zarr-conventions/spatial](https://github.com/zarr-conventions/spatial) |
 | **multiscales** | [zarr-conventions/multiscales](https://github.com/zarr-conventions/multiscales) |
 
 The [Editor’s Draft](https://zarr.dev/geozarr-spec/documents/standard/template/geozarr-spec.html) is the formal OGC spec document. It may lag behind the convention repos as it is updated periodically.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following conventions are developed or supported:
 * **Multiscales Convention** – support for pyramidal map overviews and multidimensional multiscale structures.
   Repository: [https://github.com/zarr-conventions/multiscales](https://github.com/zarr-conventions/multiscales)
 * **Geospatial Projection Convention** - defines properties that encode datum and coordinate reference system (CRS) information for geospatial data
-  Repository: [https://github.com/zarr-conventions/geo-proj](https://github.com/zarr-conventions/geo-proj)
+  Repository: [https://github.com/zarr-conventions/proj](https://github.com/zarr-conventions/proj)
 * **Spatial Convention** - describes the relationship between positional indexes and spatial coordinates (e.g., affine transformations). May be developed to support explicit coordinates and ground control points (GCPs)
   Repository: [https://github.com/zarr-conventions/spatial](https://github.com/zarr-conventions/spatial)
 


### PR DESCRIPTION
This is updates the repo contents to match the latest name of the proj convention.